### PR TITLE
Allow deleting a route without certificates

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -643,14 +643,15 @@ func (m *RouteManager) Destroy(guid string) error {
 		return err
 	}
 	var certRow Certificate
-	if err := m.db.Model(route).Related(&certRow, "Certificate").Error; err != nil {
-		return err
-	}
+	if ! m.db.Model(route).Related(&certRow).RecordNotFound() {
+		if err := m.db.Model(route).Related(&certRow, "Certificate").Error; err != nil {
+			return err
+		}
 
-	if err := m.purgeCertificate(route, &certRow); err != nil {
-		return err
+		if err := m.purgeCertificate(route, &certRow); err != nil {
+			return err
+		}
 	}
-
 	return m.db.Delete(route).Error
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -643,7 +643,7 @@ func (m *RouteManager) Destroy(guid string) error {
 		return err
 	}
 	var certRow Certificate
-	if ! m.db.Model(route).Related(&certRow).RecordNotFound() {
+	if ! m.db.Model(route).Related(&certRow, "Certificate").RecordNotFound() {
 		if err := m.db.Model(route).Related(&certRow, "Certificate").Error; err != nil {
 			return err
 		}


### PR DESCRIPTION
This works around errors when trying to delete a route that has no certificate provisioned