### PR TITLE
try to handle errors better, add some logging

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -643,20 +643,18 @@ func (m *RouteManager) Destroy(guid string) error {
 		return err
 	}
 	m.logger.info("get-related-certificate", lager.Data{
-		"guid": guid
+		"guid": guid,
 	})
 	var certRow Certificate
-	certErr := m.db.Model(route).Related(&certRow, "Certificate").Error;
-		switch certErr {
-		case nil:
-			if err := m.purgeCertificate(route, &certRow); err != nil {
-				return err
-			}
-		case gorm.ErrRecordNotFound:
-			;
-		default:
-			return certErr
+	certErr := m.db.Model(route).Related(&certRow, "Certificate").Error
+	switch certErr {
+	case nil:
+		if err := m.purgeCertificate(route, &certRow); err != nil {
+			return err
 		}
+	case gorm.ErrRecordNotFound:
+	default:
+		return certErr
 	}
 	return m.db.Delete(route).Error
 }


### PR DESCRIPTION
the logic before still seems to me like it shouldn't produce the error we're seeing, but here's a different way to do the same thing `¯\_(ツ)_/¯`

I also added a single log statement, in case this is really failing somewhere else.