### PR TITLE
select random-user to circumvent LE v1 account creation limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ A [Cloud Foundry](https://www.cloudfoundry.org/) [service broker](https://docs.c
 
 For the CDN version of this broker: https://github.com/18F/cf-cdn-service-broker
 
+## Let's Encrypt V1 End of Life
+
+The Let's Encrypt V1 endpoint is reaching end of life in June of 2020. In November of 2019, Let's Encrypt shutdown the creation of new users via the V1 API. https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430
+
+In response to disabling new user creation, this broker has been changed to use an existing user's credentials. This is implemented in `LoadRandomUser` in `models/models.go`. The pool of user ids to select from is configured via an environment variable `USER_ID_POOL`. This environment variable is injected via bosh from credhub. The envar is configured in `bosh/manifest.yml` and the value is set in credhub as `/bosh/domain-broker/user-id-pool`. These values should be set as a comma separated list in double quotes.
+
+`LoadRandomUser` will select a user from the pool, use the Let's Encrypt `reg` and `key` and create a new user entry in the broker database. Effectively, the user is the same in the eyes of Let's Encrypt but a different user in the broker database. This maintains the one user to one domain relationship in the broker database.
+
+The random selection of users from a pool aims to minimize the impact of the following rate limits:
+ *	- 300 Pending Authorizations per account
+ *	- Failed Validation limit of 5 failures per account, per hostname, per hour.
+
 ## Deployment
 
 ### Automated

--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -47,3 +47,4 @@ instance_groups:
         api_address: ((api-url))
         client_id: ((client-id))
         client_secret: ((/cf/clients/cdn-broker-secret))
+        user_id_pool: ((user-id-pool)) 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/cloudfoundry-community/go-cfclient"
@@ -24,6 +26,8 @@ import (
 func main() {
 	logger := lager.NewLogger("cf-domain-broker-alb")
 	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.INFO))
+
+	rand.Seed(time.Now().UnixNano())
 
 	settings, err := config.NewSettings()
 	if err != nil {

--- a/cmd/cron/main.go
+++ b/cmd/cron/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"math/rand"
 	"os"
 	"os/signal"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/robfig/cron"
@@ -20,6 +22,8 @@ import (
 func main() {
 	logger := lager.NewLogger("cdn-cron")
 	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.INFO))
+
+	rand.Seed(time.Now().UnixNano())
 
 	settings, err := config.NewSettings()
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -9,25 +9,26 @@ import (
 )
 
 type Settings struct {
-	Port                 string `envconfig:"port" default:"3000"`
-	BrokerUsername       string `envconfig:"broker_username" required:"true"`
-	BrokerPassword       string `envconfig:"broker_password" required:"true"`
-	DatabaseUrl          string `envconfig:"database_url" required:"true"`
-	Email                string `envconfig:"email" required:"true"`
-	AcmeUrl              string `envconfig:"acme_url" required:"true"`
-	MaxRoutes            int    `envconfig:"max_routes" default:"24"`
-	Bucket               string `envconfig:"bucket" required:"true"`
-	ALBPrefix            string `envconfig:"alb_prefix" default:"domains-broker"`
-	IamPathPrefix        string `envconfig:"iam_path_prefix" default:"/domains-broker/"`
-	AwsAccessKeyId       string `envconfig:"aws_access_key_id"`
-	AwsSecretAccessKey   string `envconfig:"aws_secret_access_key"`
-	AwsDefaultRegion     string `envconfig:"aws_default_region" required:"true"`
-	ServerSideEncryption string `envconfig:"server_side_encryption"`
-	APIAddress           string `envconfig:"api_address" required:"true"`
-	ClientID             string `envconfig:"client_id" required:"true"`
-	ClientSecret         string `envconfig:"client_secret" required:"true"`
-	Schedule             string `envconfig:"schedule" default:"0 0 * * * *"`
-	RenewDays            int    `envconfig:"renew_days" default:"30"`
+	Port                 string   `envconfig:"port" default:"3000"`
+	BrokerUsername       string   `envconfig:"broker_username" required:"true"`
+	BrokerPassword       string   `envconfig:"broker_password" required:"true"`
+	DatabaseUrl          string   `envconfig:"database_url" required:"true"`
+	Email                string   `envconfig:"email" required:"true"`
+	AcmeUrl              string   `envconfig:"acme_url" required:"true"`
+	MaxRoutes            int      `envconfig:"max_routes" default:"24"`
+	Bucket               string   `envconfig:"bucket" required:"true"`
+	ALBPrefix            string   `envconfig:"alb_prefix" default:"domains-broker"`
+	IamPathPrefix        string   `envconfig:"iam_path_prefix" default:"/domains-broker/"`
+	AwsAccessKeyId       string   `envconfig:"aws_access_key_id"`
+	AwsSecretAccessKey   string   `envconfig:"aws_secret_access_key"`
+	AwsDefaultRegion     string   `envconfig:"aws_default_region" required:"true"`
+	ServerSideEncryption string   `envconfig:"server_side_encryption"`
+	APIAddress           string   `envconfig:"api_address" required:"true"`
+	ClientID             string   `envconfig:"client_id" required:"true"`
+	ClientSecret         string   `envconfig:"client_secret" required:"true"`
+	Schedule             string   `envconfig:"schedule" default:"0 0 * * * *"`
+	RenewDays            int      `envconfig:"renew_days" default:"30"`
+	UserIdPool           []string `envconfig:"user_id_pool" required:"true"`
 }
 
 func NewSettings() (Settings, error) {


### PR DESCRIPTION
FYI: This needs to be in master so it can be packaged as a bosh release for integration testing

## Security Considerations

Because the implementation uses existing Lets Encrypt users, disabling the user in Let's Encrypt could impact renewals for multiple domains. In order to do this, the entity disabling the user in Let's Encrypt would have to gain access to the broker database. This is unlikely. Any access gained to the database would be far more catastrophic than disabling a single user.

It should be noted this broker originally operated with a single user account. It was changed to one user per domain to get around rate limits. It was not changed for security reasons (based on commit messages).